### PR TITLE
fix: rename renderBlock to renderBlockView

### DIFF
--- a/Controller/NewsWebsiteController.php
+++ b/Controller/NewsWebsiteController.php
@@ -31,7 +31,7 @@ class NewsWebsiteController extends AbstractController
         }
 
         if ($partial) {
-            $content = $this->renderBlock(
+            $content = $this->renderBlockView(
                 'news/index.html.twig',
                 'content',
                 ['news' => $news]
@@ -62,7 +62,7 @@ class NewsWebsiteController extends AbstractController
     /**
      * Returns rendered part of template specified by block.
      */
-    protected function renderBlock(mixed $template, mixed $block, mixed $attributes = [])
+    protected function renderBlockView(string $template, string $block, array $attributes = []): string
     {
         $twig = $this->container->get('twig');
         $attributes = $twig->mergeGlobals($attributes);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #67
| License | MIT

#### What's in this PR?

This package cannot be used with Symfony 6.4 because the renderBlock() method of the NewsWebsiteController conflicts with the renderBlock() method introduced in Symfony 6.4. See https://github.com/sulu/sulu/blob/3.0/UPGRADE-2.x.md#2511 for more information.

#### Why?

Allows usage of Symfony 6.4.
